### PR TITLE
Bug fixes

### DIFF
--- a/Launcher/Classes/ViewControllers/TasksViewController.swift
+++ b/Launcher/Classes/ViewControllers/TasksViewController.swift
@@ -239,7 +239,9 @@ class TasksViewController: NSViewController {
     }
     
     @IBAction func clickTagPicker(_ sender: Any) {
-        applicationStateHandler.tag = tagPicker.stringValue
+        if !tagPicker.stringValue.isEmpty {
+            applicationStateHandler.tag = tagPicker.stringValue
+        }
     }
     
     @IBAction func startTask(_ sender:AnyObject) {

--- a/Launcher/Classes/ViewControllers/TasksViewController.swift
+++ b/Launcher/Classes/ViewControllers/TasksViewController.swift
@@ -458,7 +458,7 @@ class TasksViewController: NSViewController {
         
         var arguments: [String] = []
         
-        DispatchQueue.main.async {
+        DispatchQueue.main.sync {
             if self.debugCheckbox.state == .on {
                 arguments.append("DEBUG=1")
             } else {
@@ -474,7 +474,7 @@ class TasksViewController: NSViewController {
             arguments.append("-p \(cucumberProfile)")
         }
         
-        DispatchQueue.main.async {
+        DispatchQueue.main.sync {
             // We still need an arugment to be passed, otherwise bash variable order will be spoiled
             if !self.tagPicker.stringValue.isEmpty {
                 arguments.append("--t @\(self.tagPicker.stringValue)")
@@ -492,7 +492,7 @@ class TasksViewController: NSViewController {
         let commandToExecute = plistHandler.readValues(forKey: Constants.Keys.commandFieldInfo).first ?? ""
         arguments.append(commandToExecute)
         
-        DispatchQueue.main.async {
+        DispatchQueue.main.sync {
             if let deviceIP = self.applicationStateHandler.deviceIP,
                 let bundleID = self.applicationStateHandler.bundleID,
                 self.physicalDeviceRadioButton.state == .on,


### PR DESCRIPTION
Here are two commits. 
First fixes the problem when `arguments` for the test run were filled asynchronously and therefore randomly failed. Changed all the threads to sync. 
Second fixes setting empty string in the user defaults for tag settings