### PR TITLE
Fix crash when user tries to expand the view while retrieving next view

### DIFF
--- a/Launcher/Classes/ViewControllers/InspectorViewController.swift
+++ b/Launcher/Classes/ViewControllers/InspectorViewController.swift
@@ -352,7 +352,7 @@ extension InspectorViewController: NSOutlineViewDataSource {
             return uiElements.count
         }
 
-        let currentChildIndex = uiElements.index(of: item as! String)!
+        guard let currentChildIndex = uiElements.index(of: item as! String) else { return 0 }
         isParentView = true
 
         var calculatedChildIndex = -1

--- a/Launcher/Classes/ViewControllers/InspectorViewController.swift
+++ b/Launcher/Classes/ViewControllers/InspectorViewController.swift
@@ -352,7 +352,7 @@ extension InspectorViewController: NSOutlineViewDataSource {
             return uiElements.count
         }
 
-        guard let currentChildIndex = uiElements.index(of: item as! String) else { return 0 }
+        guard let elementItem = item as? String, let currentChildIndex = uiElements.index(of: elementItem) else { return 0 }
         isParentView = true
 
         var calculatedChildIndex = -1
@@ -391,15 +391,15 @@ extension InspectorViewController: NSOutlineViewDelegate {
 
         if !isParentView {
             view = outlineView.makeView(withIdentifier: .feedCell, owner: self) as? NSTableCellView
-            if let textField = view?.textField {
+            if let textField = view?.textField, let elementItem = item as? String {
                 textField.textColor = NSColor.yellow
-                textField.stringValue = item as! String
+                textField.stringValue = elementItem
             }
         } else {
             view = outlineView.makeView(withIdentifier: .feedItemCell, owner: self) as? NSTableCellView
-            if let textField = view?.textField {
+            if let textField = view?.textField, let elementItem = item as? String {
                 textField.textColor = NSColor.cyan
-                textField.stringValue = item as! String
+                textField.stringValue = elementItem
             }
         }
         return view


### PR DESCRIPTION
When user clicks on the gesture recognisable view and tries to expand the existing view in the same time, the force unwrap will get nil. So, we better return 0 views in this case. And proceed the next one, as the previously clicked one is irrelevant.

Found this crash while investigating: https://rink.hockeyapp.net/manage/apps/687667/app_versions/1/crash_reasons/203943413

Probably the crash about has nothing to do with the crash fixed in this PR. 
@BasThomas maybe you have any thoughts?